### PR TITLE
Adding Icons to chips

### DIFF
--- a/sass/components/_chips.scss
+++ b/sass/components/_chips.scss
@@ -26,6 +26,22 @@
     line-height: 32px;
     padding-left: 8px;
   }
+  
+  .icon{
+    cursor:pointer;
+    font-size:16px;
+    line-height:32px;	
+
+    .left{
+      padding-right:8px
+    }
+    
+    .right{
+      padding-left:8px
+    }
+
+  }
+
 }
 
 .chips {


### PR DESCRIPTION
Adding ability to use material icons on chips using .icon and float to left or right using .left or .right
